### PR TITLE
Use `redis.setex` if we have a timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,23 +43,21 @@ Facilitator.prototype.generate = function (data, options) {
       data.token = token + '';
     }
 
-    _this.redis.set(key, JSON.stringify(data), function (error) {
-      if (error) {
-        error = new VError(error, 'Unable to set "%s" to the cache.', key);
-
-        _this.logger.error(error);
-
-        reject(error);
-
-        return;
+    function onset(err) {
+      if (err) {
+        err = new VError(err, "Unable to set '%s' to the cache", key);
+        _this.logger.error(err);
+        return reject(err);
       }
 
-      if (options && options.timeout) {
-        _this.redis.expire(key, options.timeout);
-      }
+      return resolve(token);
+    }
 
-      resolve(token);
-    });
+    if (options && options.timeout) {
+      _this.redis.setex(key, options.timeout, JSON.stringify(data), onset);
+    } else {
+      _this.redis.set(key, JSON.stringify(data), onset);
+    }
   });
 };
 


### PR DESCRIPTION
This makes the whole operation atomic and frees us from worrying about
what happens if Redis goes down in the middle of it.
